### PR TITLE
Provide additional capability that includes the jvmName

### DIFF
--- a/plugins/org.eclipse.justj.codegen/templates/plugin/p2.inf.jet
+++ b/plugins/org.eclipse.justj.codegen/templates/plugin/p2.inf.jet
@@ -90,6 +90,11 @@ provides.0.namespace = org.eclipse.justj
 provides.0.name = jre
 provides.0.version = $version$
 
+# Declare a capability that can be used to further identify this jvm 'type'.
+provides.1.namespace = org.eclipse.justj
+provides.1.name = <%=jvmName%>
+provides.1.version = $version$
+
 # Exclude all other providers of this capability; the site depends on all the features so exclude this requirement at build time.
 <%++count;%>
 requires.<%=count%>.matchExp = providedCapabilities.exists(x | x.name == 'jre' && x.namespace == 'org.eclipse.justj') && !providedCapabilities.exists(x | x.name == '<%=fullName%>' && x.namespace == 'org.eclipse.equinox.p2.iu')


### PR DESCRIPTION
Currently a JustJ JRE already has a capability that allows to identify *that* it is a JustJ JRE, but not of what *type* (e.g. stripped).

This adds another capability that contains the jvmName